### PR TITLE
Small fixes, and playback speed implemented

### DIFF
--- a/src/CSVloader.h
+++ b/src/CSVloader.h
@@ -85,14 +85,11 @@ public:
                             rb.second.addMarkerEntry(data);
                         }
                         
-                        
                         // loop through skeletons
                         for (auto & sk : skeletons)
                         {
                             sk.second.addSkeletonEntry(data);
                         }
-
-                        
                     }
                     
                     // clear the lock

--- a/src/MOCAP_Marker.h
+++ b/src/MOCAP_Marker.h
@@ -45,14 +45,16 @@ public:
         time.push_back(ofToFloat(data[timeNumID]));
         
         // create quarternion for rotation
-        ofQuaternion rotation(ofToFloat(data[startRot]),ofToFloat(data[startRot+1]),ofToFloat(data[startRot+2]),ofToFloat(data[startRot+3]));
+        ofQuaternion rotation(ofToFloat(data[startCollumn + startRot]),ofToFloat(data[ startCollumn + startRot+1]),ofToFloat(data[startCollumn + startRot + 2]),ofToFloat(data[startCollumn + startRot+3]));
         // create ofVec3f for position
-        ofVec3f position(ofToFloat(data[lenghtPOS]),ofToFloat(data[lenghtPOS+1]),ofToFloat(data[lenghtPOS+2]));
+        ofVec3f position(ofToFloat(data[startCollumn + startPOS]),ofToFloat(data[startCollumn + startPOS +1]),ofToFloat(data[startCollumn + startPOS + 2]));
         
         // add the position for this frame/timestamp
         positions.push_back(position);
         // add the rotation for this frame/timestamp
         rotations.push_back(rotation);
+        
+        isActive.push_back(1);
     }
     
     // send to the console the data for a specifick frame
@@ -66,13 +68,17 @@ public:
     }
     
     // Get data for specifick frame and create an OSC message for it
-    void getOSCData(int frame, ofxOscMessage *m, bool notPartSkeleton ){
+    void getOSCData(int frame, ofxOscMessage *m, bool notPartSkeleton, string prefix = "" ){
         
         if(notPartSkeleton){
-            m->setAddress("/rigidbody");
+            m->setAddress("/rigidBody");
             m->addIntArg(id);
+            m->addStringArg(name);
         }
-        m->addStringArg(name);
+        else {
+            m->addStringArg(prefix + name);
+        }
+        
         // add position
         ofVec3f position = positions[frame]; // FIXME: better to do with map and lookup?
         m->addFloatArg(position.x);
@@ -86,16 +92,31 @@ public:
         m->addFloatArg(rotation.z());
         m->addFloatArg(rotation.w());
         
-        // add position speed
-        // TODO: position speed
-        
-        // add rotation speed
-        // TODO: add rotation speed
-        
-        // add is active
-        // TODO: add is active
-        
-        
+        ///skeleton specific
+        if ( notPartSkeleton ) {
+            // add position speed
+            // TODO: position speed (currently 0)
+            m->addFloatArg(0);
+            m->addFloatArg(0);
+            m->addFloatArg(0);
+            
+            // add rotation speed
+            // TODO: add rotation speed (currently 0)
+            m->addFloatArg(0);
+            m->addFloatArg(0);
+            m->addFloatArg(0);
+            
+            // add is active
+            // TODO: add is active (currently always active)
+            m->addIntArg(1);
+        }
+        else {
+            // add parent bone index
+            // TODO: parent id
+            
+            // add parent offset (xyz)
+            // TODO: add parent offset
+        }
     }
     
     // return the collumn in the file where the data starts
@@ -135,14 +156,19 @@ protected:
     std::vector<float> time;
     std::vector<ofVec3f> positions;
     std::vector<ofQuaternion> rotations;
+    std::vector<int> isActive;
     
     // Definition of the OPTITRACK MOCAP RIGID BODIE Data string
     // defines how the data structure in the CSV file is written
+    
+    //global for all frames
     int frameNumID = 0;
     int timeNumID = 1;
-    int startPOS = 6;
+    
+    //relative to startColumn
+    int startPOS = 4;
     int lenghtPOS = 3;
-    int startRot = 2;
+    int startRot = 0;
     int lengthRot = 4;
     
 };

--- a/src/MOCAP_Skeleton.h
+++ b/src/MOCAP_Skeleton.h
@@ -105,7 +105,7 @@ public:
             m.setAddress("/skeleton/"+name+"/"+bone.getName());
             // add position
             ofVec3f position = bone.getPosition(frame); // FIXME: better to do with map and lookup?
-            if ( mode -= ClientMode_FullSkeleton ) {
+            if ( mode == ClientMode_FullSkeleton ) {
                 m.addStringArg(name + "_" + bone.getName());
             }
             else {

--- a/src/MOCAP_Skeleton.h
+++ b/src/MOCAP_Skeleton.h
@@ -9,6 +9,9 @@
 #ifndef MOCAP_Skeleton_h
 #define MOCAP_Skeleton_h
 
+#include "client.h"
+
+
 
 class MOCAP_Skeleton{
 public:
@@ -68,15 +71,21 @@ public:
     }
     
     // get the data of the skeleton for a specific frame and return as osc message
-    ofxOscMessage getOSCData(int frame){
+    ofxOscMessage getOSCData(int frame, ClientMode mode ){
         ofxOscMessage m;
         m.setAddress("/skeleton");
-        m.addIntArg(id);
         m.addStringArg(name);
+        m.addIntArg(id);
         
         // loop through the bones
         for( MOCAP_Marker &bone : bones){
-            bone.getOSCData(frame,&m, false);
+            // full skeleton adds skeleton prefix to bone name
+            if ( mode == ClientMode_FullSkeleton ) {
+                bone.getOSCData(frame,&m,false,name+"_");
+            }
+            else {
+                bone.getOSCData(frame,&m,false);
+            }
         }
         
         return m;
@@ -84,7 +93,7 @@ public:
     
     // get the data of the skeleton for a specific frame and return as osc message
     // /skeleton/skeletonname/bone
-    std::vector<ofxOscMessage> getOSCDataHierarchy(int frame){
+    std::vector<ofxOscMessage> getOSCDataHierarchy(int frame, ClientMode mode ){
         
         
        std::vector<ofxOscMessage> messages;
@@ -96,7 +105,12 @@ public:
             m.setAddress("/skeleton/"+name+"/"+bone.getName());
             // add position
             ofVec3f position = bone.getPosition(frame); // FIXME: better to do with map and lookup?
-            m.addStringArg(bone.getName());
+            if ( mode == ClientMode_FullSkeleton ) {
+                m.addStringArg(bone.getName());
+            }
+            else {
+                m.addStringArg(name + "_" + bone.getName());
+            }
             m.addFloatArg(position.x);
             m.addFloatArg(position.y);
             m.addFloatArg(position.z);
@@ -114,9 +128,6 @@ public:
         
         return messages;
     }
-
-    
-    
     
 protected:
     std::vector<MOCAP_Marker> bones;

--- a/src/MOCAP_Skeleton.h
+++ b/src/MOCAP_Skeleton.h
@@ -105,11 +105,11 @@ public:
             m.setAddress("/skeleton/"+name+"/"+bone.getName());
             // add position
             ofVec3f position = bone.getPosition(frame); // FIXME: better to do with map and lookup?
-            if ( mode == ClientMode_FullSkeleton ) {
-                m.addStringArg(bone.getName());
+            if ( mode -= ClientMode_FullSkeleton ) {
+                m.addStringArg(name + "_" + bone.getName());
             }
             else {
-                m.addStringArg(name + "_" + bone.getName());
+                m.addStringArg(bone.getName());
             }
             m.addFloatArg(position.x);
             m.addFloatArg(position.y);

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -10,7 +10,6 @@
 #include "ofxXmlSettings.h"
 #include "client.h"
 
-
 #define HOST "192.168.0.105"
 #define PORT 1234
 
@@ -41,6 +40,7 @@ class ofApp : public ofBaseApp{
         void saveData();
         void setupData();
         void setFPS();
+        void doFrame();
     
         void deactivateInputs();
     
@@ -52,8 +52,12 @@ class ofApp : public ofBaseApp{
     
         bool dataLoaded;
         int frameNum;
+        float fFrameNum;
         int totalFrames;
         int frameRate;
+        float frameTime;
+        float fTimeCounter;
+    
         std::map<string,MOCAP_Marker> rigidbodies;
         std::map<string,MOCAP_Skeleton> skeletons;
         ofxOscSender sender;


### PR DESCRIPTION
Framerate of the OSC send-loop is now independent of the ofFrameRate (but not threaded, this is still a TODO). Only a single packet (bundle) is sent each time a frame-step is made (not constantly even though the frame hasn't changed).

Found an issue in the rigidbody position/rotation import on the CSV side, so fixed that. And I aligned the way messages are sent with how the NatNet2OSCBridge does it (Full Skeleton client mode includes prefix, "rigidBody" instead of "rigidbody", and the hierarchy / non-hierarchy difference in both rigidbodies and skeletons).

Discovered Skeleton data in the CSV does not store parent indices & offsets. We'll need to think about how to fix this (default data on the Unity side, or different file format?) because Unity can't create avatars without this data.